### PR TITLE
fix: 连接池懒加载+有效性校验,驱动资源清理与友好错误提示

### DIFF
--- a/src/main/java/com/data/pivot/plugin/config/DataPivotInitializer.java
+++ b/src/main/java/com/data/pivot/plugin/config/DataPivotInitializer.java
@@ -2,7 +2,9 @@ package com.data.pivot.plugin.config;
 
 
 import com.data.pivot.plugin.entity.custom.DataPivotStrategyInfo;
+import com.data.pivot.plugin.tool.DataSourceDriverUtil;
 import com.data.pivot.plugin.tool.DatabaseUtil;
+import com.data.pivot.plugin.tool.QueryTool;
 import com.data.pivot.plugin.context.DataPivotApplication;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
@@ -16,6 +18,8 @@ public class DataPivotInitializer implements StartupActivity.DumbAware {
         initDataPivotDatabaseInfo(project);
         initDataPivotSettingInfo(project);
         Disposer.register(project, DatabaseUtil::closeConnections);
+        Disposer.register(project, QueryTool::closeAllConnections);
+        Disposer.register(project, DataSourceDriverUtil::deregisterAllDrivers);
     }
 
     static void initDefaultStrategy(DataPivotApplication application) {

--- a/src/main/java/com/data/pivot/plugin/tool/DataGripUtil.java
+++ b/src/main/java/com/data/pivot/plugin/tool/DataGripUtil.java
@@ -80,9 +80,12 @@ public class DataGripUtil {
     }
 
     private static void collectNamingNames(TreePatternNode node, List<String> names) {
+        if (node == null) {
+            return;
+        }
         if (node.naming != null && node.naming.names != null) {
             for (ObjectName name : node.naming.names) {
-                if (name.name != null && !name.name.isBlank() && !names.contains(name.name)) {
+                if (name != null && name.name != null && !name.name.isBlank() && !names.contains(name.name)) {
                     names.add(name.name);
                 }
             }
@@ -91,11 +94,13 @@ public class DataGripUtil {
             return;
         }
         for (TreePatternNode.Group group : node.groups) {
-            if (group.children == null) {
+            if (group == null || group.children == null) {
                 continue;
             }
             for (TreePatternNode child : group.children) {
-                collectNamingNames(child, names);
+                if (child != null) {
+                    collectNamingNames(child, names);
+                }
             }
         }
     }

--- a/src/main/java/com/data/pivot/plugin/tool/DataSourceDriverUtil.java
+++ b/src/main/java/com/data/pivot/plugin/tool/DataSourceDriverUtil.java
@@ -1,5 +1,6 @@
 package com.data.pivot.plugin.tool;
 
+import com.data.pivot.plugin.i18n.DataPivotBundle;
 import com.intellij.database.dataSource.DatabaseDriver;
 import com.intellij.database.dataSource.LocalDataSource;
 import com.intellij.database.dataSource.artifacts.DatabaseArtifactContext;
@@ -7,6 +8,7 @@ import com.intellij.database.dataSource.artifacts.DatabaseArtifactDefaultContext
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.util.ui.classpath.SimpleClasspathElement;
 
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
@@ -26,7 +28,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 public final class DataSourceDriverUtil {
-    private static final ConcurrentMap<String, Driver> REGISTERED_DRIVERS = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<String, RegisteredDriver> REGISTERED_DRIVERS = new ConcurrentHashMap<>();
 
     private DataSourceDriverUtil() {
     }
@@ -64,32 +66,70 @@ public final class DataSourceDriverUtil {
 
         List<String> roots = classRootUrls == null ? Collections.emptyList() : classRootUrls;
         String key = driverClassName + "@" + String.join("|", roots);
-        REGISTERED_DRIVERS.computeIfAbsent(key, ignored -> registerDriver(dataSourceId, driverClassName, roots));
+        REGISTERED_DRIVERS.computeIfAbsent(key, ignored -> registerDriver(driverClassName, roots));
     }
 
-    private static Driver registerDriver(String dataSourceId, String driverClassName, List<String> classRootUrls) {
+    private static RegisteredDriver registerDriver(String driverClassName, List<String> classRootUrls) {
+        URLClassLoader classLoader = null;
         try {
-            Driver driver = createDriver(driverClassName, classRootUrls);
+            Driver driver;
+            if (classRootUrls.isEmpty()) {
+                driver = (Driver) Class.forName(driverClassName).getDeclaredConstructor().newInstance();
+            } else {
+                classLoader = createClassLoader(classRootUrls);
+                driver = (Driver) Class.forName(driverClassName, true, classLoader).getDeclaredConstructor().newInstance();
+            }
             Driver shim = new DriverShim(driver);
             DriverManager.registerDriver(shim);
-            return shim;
+            return new RegisteredDriver(shim, classLoader);
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
+            // 驱动 jar 尚未下载到本地(或 jar 内不含该驱动类),引导用户先在 DataGrip 数据源里下载该驱动。
+            closeQuietly(classLoader);
+            throw new IllegalStateException(
+                    DataPivotBundle.message("data.pivot.driver.not.downloaded", driverClassName), e);
         } catch (Exception e) {
-            throw new IllegalStateException("Failed to register database driver for " + dataSourceId + ": " + driverClassName, e);
+            closeQuietly(classLoader);
+            throw new IllegalStateException(
+                    DataPivotBundle.message("data.pivot.driver.register.fail", driverClassName, String.valueOf(e.getMessage())), e);
         }
     }
 
-    private static Driver createDriver(String driverClassName, List<String> classRootUrls) throws Exception {
-        if (classRootUrls.isEmpty()) {
-            return (Driver) Class.forName(driverClassName).getDeclaredConstructor().newInstance();
-        }
-
+    private static URLClassLoader createClassLoader(List<String> classRootUrls) throws Exception {
         List<URL> urls = new ArrayList<>();
         for (String rootUrl : classRootUrls) {
             urls.add(toUrl(rootUrl));
         }
+        return new URLClassLoader(urls.toArray(new URL[0]), DataSourceDriverUtil.class.getClassLoader());
+    }
 
-        URLClassLoader classLoader = new URLClassLoader(urls.toArray(new URL[0]), DataSourceDriverUtil.class.getClassLoader());
-        return (Driver) Class.forName(driverClassName, true, classLoader).getDeclaredConstructor().newInstance();
+    /**
+     * 释放本工具注册过的驱动 shim 及其 {@link URLClassLoader}。应在项目/插件 dispose 时调用,
+     * 避免 DriverManager 中的 shim 与类加载器长期驻留;下次查询会按需重新注册。
+     */
+    public static void deregisterAllDrivers() {
+        for (RegisteredDriver registered : REGISTERED_DRIVERS.values()) {
+            try {
+                DriverManager.deregisterDriver(registered.shim());
+            } catch (SQLException ignored) {
+                // best-effort cleanup on dispose
+            }
+            closeQuietly(registered.classLoader());
+        }
+        REGISTERED_DRIVERS.clear();
+    }
+
+    private static void closeQuietly(URLClassLoader classLoader) {
+        if (classLoader == null) {
+            return;
+        }
+        try {
+            classLoader.close();
+        } catch (IOException ignored) {
+            // best-effort cleanup
+        }
+    }
+
+    private record RegisteredDriver(Driver shim, URLClassLoader classLoader) {
     }
 
     private static URL toUrl(String rootUrl) throws Exception {

--- a/src/main/java/com/data/pivot/plugin/tool/QueryTool.java
+++ b/src/main/java/com/data/pivot/plugin/tool/QueryTool.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * 查询工具类，复用 IntelliJ IDEA Database Tools 中已配置的数据源驱动。
@@ -31,7 +32,8 @@ public class QueryTool {
     private static final int LIMIT = 20;
     private static final int QUERY_TIMEOUT = 5;
     private static final int MAX_CONNECTIONS = 10;
-    private static final ConcurrentMap<String, BlockingQueue<Connection>> connectionPools = new ConcurrentHashMap<>();
+    private static final int VALIDATION_TIMEOUT = 2;
+    private static final ConcurrentMap<String, ConnectionPool> connectionPools = new ConcurrentHashMap<>();
 
     private static Connection getConnection(DatabaseQueryConfig config) throws InterruptedException, SQLException {
         if (DBType.MONGO.equals(config.getDbType())) {
@@ -45,22 +47,12 @@ public class QueryTool {
         );
 
         String poolKey = config.getDataSourceId() + "@" + config.getUrl();
-        BlockingQueue<Connection> pool = getOrCreateConnectionPool(poolKey, config);
-        return pool.poll(QUERY_TIMEOUT, TimeUnit.SECONDS);
+        ConnectionPool pool = getOrCreateConnectionPool(poolKey, config);
+        return pool.acquire();
     }
 
-    private static BlockingQueue<Connection> getOrCreateConnectionPool(String poolKey, DatabaseQueryConfig config) {
-        return connectionPools.computeIfAbsent(poolKey, id -> {
-            BlockingQueue<Connection> pool = new LinkedBlockingQueue<>(MAX_CONNECTIONS);
-            for (int i = 0; i < MAX_CONNECTIONS; i++) {
-                try {
-                    pool.offer(createConnection(config));
-                } catch (SQLException e) {
-                    throw new RuntimeException("Failed to create a new connection", e);
-                }
-            }
-            return pool;
-        });
+    private static ConnectionPool getOrCreateConnectionPool(String poolKey, DatabaseQueryConfig config) {
+        return connectionPools.computeIfAbsent(poolKey, id -> new ConnectionPool(config));
     }
 
     private static Connection createConnection(DatabaseQueryConfig config) throws SQLException {
@@ -97,10 +89,15 @@ public class QueryTool {
     }
 
     private static void releaseConnection(DatabaseQueryConfig config, Connection connection) {
+        if (connection == null) {
+            return;
+        }
         String poolKey = config.getDataSourceId() + "@" + config.getUrl();
-        BlockingQueue<Connection> pool = connectionPools.get(poolKey);
+        ConnectionPool pool = connectionPools.get(poolKey);
         if (pool != null) {
-            pool.offer(connection);
+            pool.release(connection);
+        } else {
+            ConnectionPool.closeQuietly(connection);
         }
     }
 
@@ -197,18 +194,121 @@ public class QueryTool {
     }
 
     public static void closeAllConnections() {
-        connectionPools.values().forEach(pool -> {
-            while (!pool.isEmpty()) {
-                try {
-                    Connection connection = pool.poll();
-                    if (connection != null) {
-                        connection.close();
-                    }
-                } catch (SQLException ignored) {
-                    // Ignore close failures while disposing pooled connections.
-                }
-            }
-        });
+        connectionPools.values().forEach(ConnectionPool::closeAll);
         connectionPools.clear();
+    }
+
+    /**
+     * 懒加载连接池:连接按需创建(上限 {@link #MAX_CONNECTIONS}),取用时通过 {@link Connection#isValid(int)}
+     * 校验有效性,失效连接会被丢弃并按需重建。相比一次性预建连接,既避免首次查询因单个连接创建失败而整体抛错,
+     * 也避免长时间空闲后使用到已被数据库侧断开的 stale 连接。
+     */
+    private static final class ConnectionPool {
+        private final DatabaseQueryConfig config;
+        private final BlockingQueue<Connection> idle = new LinkedBlockingQueue<>(MAX_CONNECTIONS);
+        private final AtomicInteger total = new AtomicInteger(0);
+
+        private ConnectionPool(DatabaseQueryConfig config) {
+            this.config = config;
+        }
+
+        /**
+         * 取出一个可用连接;池内无空闲且未达上限时新建,达到上限则等待归还,超时返回 {@code null}。
+         */
+        private Connection acquire() throws SQLException, InterruptedException {
+            long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(QUERY_TIMEOUT);
+            while (true) {
+                Connection pooled = idle.poll();
+                if (pooled != null) {
+                    if (isUsable(pooled)) {
+                        return pooled;
+                    }
+                    discard(pooled);
+                    continue;
+                }
+                if (tryReserveSlot()) {
+                    try {
+                        return createConnection(config);
+                    } catch (SQLException e) {
+                        total.decrementAndGet();
+                        throw e;
+                    }
+                }
+                long remainingNanos = deadlineNanos - System.nanoTime();
+                if (remainingNanos <= 0) {
+                    return null;
+                }
+                pooled = idle.poll(remainingNanos, TimeUnit.NANOSECONDS);
+                if (pooled == null) {
+                    return null;
+                }
+                if (isUsable(pooled)) {
+                    return pooled;
+                }
+                discard(pooled);
+            }
+        }
+
+        /**
+         * 归还连接:已关闭或池已满则直接释放,否则放回空闲队列。
+         */
+        private void release(Connection connection) {
+            if (connection == null) {
+                return;
+            }
+            if (isClosedQuietly(connection) || !idle.offer(connection)) {
+                discard(connection);
+            }
+        }
+
+        private boolean tryReserveSlot() {
+            int current;
+            do {
+                current = total.get();
+                if (current >= MAX_CONNECTIONS) {
+                    return false;
+                }
+            } while (!total.compareAndSet(current, current + 1));
+            return true;
+        }
+
+        private void discard(Connection connection) {
+            closeQuietly(connection);
+            total.decrementAndGet();
+        }
+
+        private void closeAll() {
+            Connection connection;
+            while ((connection = idle.poll()) != null) {
+                closeQuietly(connection);
+            }
+            total.set(0);
+        }
+
+        private static boolean isUsable(Connection connection) {
+            try {
+                return connection != null && !connection.isClosed() && connection.isValid(VALIDATION_TIMEOUT);
+            } catch (SQLException e) {
+                return false;
+            }
+        }
+
+        private static boolean isClosedQuietly(Connection connection) {
+            try {
+                return connection.isClosed();
+            } catch (SQLException e) {
+                return true;
+            }
+        }
+
+        private static void closeQuietly(Connection connection) {
+            try {
+                if (connection != null) {
+                    connection.close();
+                }
+            } catch (SQLException ignored) {
+                // Ignore close failures while disposing pooled connections.
+            }
+        }
     }
 }

--- a/src/main/resources/messages/DataPivotBundle.properties
+++ b/src/main/resources/messages/DataPivotBundle.properties
@@ -11,6 +11,8 @@ data.pivot.notice.setting.null.action = \u6253\u5F00 data-pivot \u914D\u7F6E\u98
 data.pivot.notice.connection.null = {0} \u6570\u636E\u5E93\u8FDE\u63A5\u5F02\u5E38,\u8BF7\u68C0\u67E5 DataGrip \u8BE5\u6570\u636E\u6E90\u8FDE\u63A5\u60C5\u51B5\u540E\u5237\u65B0
 data.pivot.notice.connection.driver.null = {0} \u6570\u636E\u5E93\u9A71\u52A8\u4E0D\u5B58\u5728
 data.pivot.notice.rom.data.error = \u52A0\u8F7D{0}\u6570\u636E\u5931\u8D25,\u5F02\u5E38\u4FE1\u606F{1}
+data.pivot.driver.not.downloaded = {0} \u9A71\u52A8\u5C1A\u672A\u4E0B\u8F7D,\u8BF7\u5148\u5728 DataGrip \u6570\u636E\u6E90\u8BBE\u7F6E\u4E2D\u4E0B\u8F7D\u8BE5\u6570\u636E\u5E93\u9A71\u52A8\u540E\u91CD\u8BD5
+data.pivot.driver.register.fail = {0} \u9A71\u52A8\u6CE8\u518C\u5931\u8D25:{1}
 
 data.pivot.dialog.setting.repeat = {0} \u5DF2\u5B58\u5728\u5BF9\u5E94\u7684 mapping ,\u4E0D\u53EF\u4EE5\u91CD\u590D
 data.pivot.dialog.setting.module = module

--- a/src/main/resources/messages/DataPivotBundle_en_US.properties
+++ b/src/main/resources/messages/DataPivotBundle_en_US.properties
@@ -11,6 +11,8 @@ data.pivot.notice.setting.null.action = open the data-pivot configuration page
 data.pivot.notice.connection.null = {0} The database connection is abnormal, check the DataGrip connection status of the data source and refresh it
 data.pivot.notice.connection.driver.null = {0} The database driver does not exist
 data.pivot.notice.rom.data.error = Loading {0} data failed, exception message: {1}
+data.pivot.driver.not.downloaded = The database driver "{0}" has not been downloaded yet. Open the data source settings in DataGrip / Database Tools, download the driver, then try again.
+data.pivot.driver.register.fail = Failed to register the database driver "{0}": {1}
 
 data.pivot.dialog.setting.repeat = {0} The corresponding mapping already exists and cannot be repeated
 data.pivot.dialog.setting.module = module

--- a/src/main/resources/messages/DataPivotBundle_zh_CN.properties
+++ b/src/main/resources/messages/DataPivotBundle_zh_CN.properties
@@ -11,6 +11,8 @@ data.pivot.notice.setting.null.action = \u6253\u5F00 data-pivot \u914D\u7F6E\u98
 data.pivot.notice.connection.null = {0} \u6570\u636E\u5E93\u8FDE\u63A5\u5F02\u5E38,\u8BF7\u68C0\u67E5 DataGrip \u8BE5\u6570\u636E\u6E90\u8FDE\u63A5\u60C5\u51B5\u540E\u5237\u65B0
 data.pivot.notice.connection.driver.null = {0} \u6570\u636E\u5E93\u9A71\u52A8\u4E0D\u5B58\u5728
 data.pivot.notice.rom.data.error = \u52A0\u8F7D{0}\u6570\u636E\u5931\u8D25,\u5F02\u5E38\u4FE1\u606F{1}
+data.pivot.driver.not.downloaded = {0} \u9A71\u52A8\u5C1A\u672A\u4E0B\u8F7D,\u8BF7\u5148\u5728 DataGrip \u6570\u636E\u6E90\u8BBE\u7F6E\u4E2D\u4E0B\u8F7D\u8BE5\u6570\u636E\u5E93\u9A71\u52A8\u540E\u91CD\u8BD5
+data.pivot.driver.register.fail = {0} \u9A71\u52A8\u6CE8\u518C\u5931\u8D25:{1}
 
 data.pivot.dialog.setting.repeat = {0} \u5DF2\u5B58\u5728\u5BF9\u5E94\u7684 mapping ,\u4E0D\u53EF\u4EE5\u91CD\u590D
 data.pivot.dialog.setting.module = module


### PR DESCRIPTION
## 背景

针对 `4ce8355 (chore: prepare 2.1.0 release)` 引入的连接池 / 驱动加载逻辑做健壮性修复。逐条核对了 review 中提出的 5 个问题,均**确认存在**,本 PR 全部处理。

| # | 问题 | 结论 | 严重度 |
|---|------|------|--------|
| 1 | `getOrCreateConnectionPool` 一次性预建 10 个连接,任一失败抛 `RuntimeException`(首次查询即整体失败)。另外存在隐藏 bug:中途失败时已建连接泄漏、`computeIfAbsent` 未缓存导致每次重试都重开 10 个 | 确认 | 高 |
| 2 | 池化连接无失效检测(只 `poll`/`offer`),长时间空闲后可能 stale | 确认 | 高 |
| 3 | `URLClassLoader` 与 `DriverShim` 永不释放;且 `closeAllConnections()` **从未被调用**,连接同样泄漏 | 确认 | 低 |
| 4 | `collectNamingNames` 递归未判 `child != null` | 确认 | 低 |
| 5 | 驱动未下载直接抛 `IllegalStateException`,提示不友好 | 确认 | 低 |

## 改动

**`QueryTool`(问题 1、2)** —— 连接池改为懒加载:
- 连接**按需创建**(上限 `MAX_CONNECTIONS=10`),首次查询只建 1 个,不再一次性预建 10 个;
- 取连接时用 `Connection.isValid(2s)` 校验,**失效则关闭丢弃并重建**,规避数据库侧断连后的 stale 连接;
- 单连接创建失败只抛 `SQLException`、**不污染连接池且不泄漏**(预占的 slot 会回退),下次查询可正常恢复;
- 归还时检测是否已关闭,已关闭/池满则释放而非塞回。

**`DataSourceDriverUtil`(问题 3、5)**:
- 用 record 跟踪注册的 `shim` 与 `URLClassLoader`,新增 `deregisterAllDrivers()`,dispose 时反注册并 `close()` 类加载器;
- 驱动未下载(`ClassNotFoundException` / `NoClassDefFoundError`)时给出**可操作的友好提示**,引导用户先在 DataGrip 数据源里下载该驱动;其余失败走通用提示。

**`DataPivotInitializer`(问题 3)** —— 项目 dispose 时一并清理连接池与已注册驱动(此前 `closeAllConnections` 从未被注册,连接会一直泄漏)。

**`DataGripUtil`(问题 4)** —— `collectNamingNames` 递归补全 `node` / `group` / `child` / `name` 的 null 防御。

**i18n** —— 新增 `data.pivot.driver.not.downloaded`、`data.pivot.driver.register.fail` 的中英文文案(default / zh_CN / en_US)。

## 验证

由于本环境网络策略屏蔽了 JetBrains 仓库(`download.jetbrains.com` 返回 403),无法跑完整 Gradle 构建。连接池是最易出错的部分,因此用**与补丁完全一致的方法体**(仅把 `createConnection` 换成可控的 `java.sql.Connection` 动态代理)写了独立用例验证,18 项断言全部通过:

- 懒加载:首次 acquire 只建 1 个(旧逻辑建 10);
- stale(`isValid=false`)连接不下发、被关闭并重建,计数不漂移;
- 归还时外部已关闭的连接被丢弃而非入池;
- 容量上限封顶、超时返回 null(实测 ~5s);
- 创建失败抛 `SQLException` 不泄漏 slot,且后续可恢复;
- `closeAll` 正确清空并归零计数。

> 注:`ensureDriverRegistered` 的公开签名保持不变(仍含 `dataSourceId` 上下文参数),调用方无需改动。

https://claude.ai/code/session_01HYez8dwWXxDUsygNsoKWT9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYez8dwWXxDUsygNsoKWT9)_