### PR TITLE
Improve release workflow to handle draft releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,21 @@ jobs:
 
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-          if git rev-parse --verify --quiet "refs/tags/$version" >/dev/null || \
-             gh release view "$version" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "Version $version already has a tag or release; nothing to publish."
+          # A published git tag means the version is already released; never rebuild it.
+          if git rev-parse --verify --quiet "refs/tags/$version" >/dev/null; then
+            echo "Version $version already has a tag; nothing to publish."
             echo "is_new_version=false" >> "$GITHUB_OUTPUT"
+          elif is_draft=$(gh release view "$version" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft' 2>/dev/null); then
+            # A release with this version already exists. Only a published release is
+            # final: an existing draft must be rebuilt so its assets and target commit
+            # track the latest push instead of remaining stuck on the first run.
+            if [[ "$is_draft" == "true" ]]; then
+              echo "Version $version has an existing draft release; it will be rebuilt and refreshed."
+              echo "is_new_version=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "Version $version already has a published release; nothing to publish."
+              echo "is_new_version=false" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "Version $version is new and will be released."
             echo "is_new_version=true" >> "$GITHUB_OUTPUT"
@@ -153,6 +164,7 @@ jobs:
             gh release edit "$VERSION" \
               --repo "$GITHUB_REPOSITORY" \
               --draft \
+              --target "$GITHUB_SHA" \
               --title "$VERSION" \
               --notes-file build/tmp/release-note.md
             gh release upload "$VERSION" "${distributions[@]}" \


### PR DESCRIPTION
**What type of change does this PR introduce?**

- [ ] Bug fix. Bug修复
- [x] New feature. 新功能
- [ ] Code style update. 代码风格更新
- [ ] Refactoring. 功能重构
- [x] Build-related changes. 编译&构建相关的更改
- [ ] Other, please describe: 其他，请描述：

**Description of the PR:**

This PR improves the GitHub Actions release workflow to properly handle draft releases:

1. **Separate git tag and release checks**: The version check now distinguishes between git tags (which indicate a final release) and GitHub releases (which may be drafts). A published git tag will always skip publishing, but a draft release will be rebuilt.

2. **Draft release detection**: Added logic to detect whether an existing release is a draft or published using `gh release view` with JSON output. Draft releases are treated as incomplete and will be rebuilt on subsequent runs.

3. **Update release target commit**: When editing a draft release, the `--target` flag is now set to `$GITHUB_SHA` to ensure the release points to the latest commit from the current push, rather than remaining stuck on the first run's commit.

This ensures that:
- Published releases are never rebuilt
- Draft releases are automatically refreshed with the latest assets and target the correct commit
- New versions are properly released as expected

**Additional information:**

The changes maintain backward compatibility while fixing the issue where draft releases would not be updated on subsequent workflow runs. The workflow now correctly handles the three states: new version, existing draft (rebuild), and existing published release (skip).

https://claude.ai/code/session_018XCj3HBJS5eEcXCT9dA5GQ